### PR TITLE
Adding columns from CISS GV and CRASH tables to CISS patient table

### DIFF
--- a/CISS/transforms/CISS_Constants.py
+++ b/CISS/transforms/CISS_Constants.py
@@ -2,12 +2,25 @@ from CISS_Injury_Value_Map import ciss_injury_col_specific_value_maps
 from CISS_Patient_Value_Map import ciss_patient_col_specific_value_maps
 
 # Injury Constants
-injury_join_columns = ['CASEID', 'CASENO', 'VEHNO', 'OCCNO', 'INJNO']
-injury_output_columns = injury_join_columns + ['YEAR', 'AISCODE', 'AIS', 'REGION', 'STRUTYPE', 'STRUSPEC', 'INJLEVEL',
-                                               'L1', 'L2', 'LDEF']
+injury_join_columns_list = [['CASEID', 'CASENO', 'VEHNO', 'OCCNO', 'INJNO']]
+injury_use_cols_list = [injury_join_columns_list[0] + ['L1', 'L2', 'LDEF']]
+injury_output_columns = injury_join_columns_list[0] + ['YEAR', 'AISCODE', 'AIS', 'REGION', 'STRUTYPE', 'STRUSPEC',
+                                                       'INJLEVEL', 'L1', 'L2', 'LDEF']
 
 # Patient Constants
-patient_join_columns = ['CASEID', 'PSU', 'CASENO', 'VEHNO', 'OCCNO']
-patient_output_columns = patient_join_columns + ['YEAR', 'AGE', 'SEX', 'HEIGHT', 'WEIGHT', 'ROLE', 'PARBELTUSE',
-                                                 'PARAIRBAG', 'SEATLOC', 'ENTRAP', 'EYEWEAR', 'HOSPSTAY', 'MOBILITY',
-                                                 'MORTALITY', 'TREATMENT', 'EJECTTYPE']
+patient_base_column_list = ['CASEID', 'PSU', 'CASENO']
+patient_join_columns_list = [patient_base_column_list + ['VEHNO', 'OCCNO'], patient_base_column_list + ['VEHNO'],
+                             patient_base_column_list]
+patient_use_cols_list = [patient_base_column_list + ['VEHNO', 'OCCNO', 'EJECTTYPE'],
+                         patient_base_column_list + ['VEHNO', 'CURBWT', 'DVTOTAL'],
+                         patient_base_column_list + ['EVENTS']]
+patient_output_columns = patient_join_columns_list[0] + ['YEAR', 'AGE', 'SEX', 'HEIGHT', 'WEIGHT', 'ROLE', 'PARBELTUSE',
+                                                         'PARAIRBAG', 'SEATLOC', 'ENTRAP', 'EYEWEAR', 'HOSPSTAY',
+                                                         'MOBILITY', 'MORTALITY', 'TREATMENT', 'EJECTTYPE', 'CURBWT',
+                                                         'DVTOTAL', 'EVENTS']
+intrusion_base_column_list = ['CASEID', 'PSU', 'CASENO', 'VEHNO', 'YEAR']
+seat_loc_intrusion_column_list = intrusion_base_column_list + ['SEATLOC']
+intrusion_output_columns = seat_loc_intrusion_column_list + ['INTRUNO', 'INTRUSION', 'INTDIRECT']
+
+# Encoding Constants
+ciss_years_with_wlatin1_encoding = ['2017', '2018', '2019', '2020', '2021']

--- a/CISS/transforms/CISS_Injury_Cleaning.py
+++ b/CISS/transforms/CISS_Injury_Cleaning.py
@@ -9,18 +9,22 @@
 # Import injury constants and functions
 import CISS_Utils
 import CISS_Constants
+import Global_Utils
 
 # Assign raw and clean directories
 injury_raw_zipped_directory = '../raw'
 injury_clean_directory = '../clean'
 
-# Setting injury, localizer and output filenames
-injury_filename = 'INJURY'
-localizer_filename = 'LOCALIZER'
-output_filename = injury_clean_directory + '/INJURY_CLEANED.csv'
+# Setting the list of input filenames and the output filename
+injury_input_filename_list = ['INJURY', 'LOCALIZER']
+injury_output_filename = injury_clean_directory + '/INJURY_CLEANED.csv'
 
 # Using the clean_zip_files function to join the injury and localizer files for each year in CISS
 # and then union each years file into an injury dataset
-CISS_Utils.clean_zip_files(injury_raw_zipped_directory, injury_filename, localizer_filename,
-                           CISS_Constants.injury_join_columns, CISS_Constants.injury_output_columns,
-                           CISS_Constants.ciss_injury_col_specific_value_maps, output_filename)
+ciss_injury_df = CISS_Utils.clean_zip_files(injury_raw_zipped_directory, injury_input_filename_list,
+                                            CISS_Constants.injury_join_columns_list,
+                                            CISS_Constants.injury_use_cols_list, CISS_Constants.injury_output_columns)
+
+ciss_injury_df = Global_Utils.clean_column_values(ciss_injury_df, CISS_Constants.ciss_injury_col_specific_value_maps, {})
+
+ciss_injury_df.to_csv(injury_output_filename, encoding='utf-8', index=False)

--- a/CISS/transforms/CISS_Patient_Cleaning.py
+++ b/CISS/transforms/CISS_Patient_Cleaning.py
@@ -1,18 +1,59 @@
 # Import patient constants and functions
 import CISS_Utils
 import CISS_Constants
+import Global_Utils
 
 # Assign raw and clean directories
 patient_raw_zipped_directory = '../raw'
 patient_clean_directory = '../clean'
 
-# Setting occupant, eject and output filenames
-occupant_filename = 'OCC'
-eject_filename = 'EJECT'
-output_filename = patient_clean_directory + '/PATIENT_CLEANED.csv'
+# Setting input file name lists and output filename
+patient_base_input_filename_list = ['OCC', 'EJECT', 'GV', 'CRASH']
+intrusion_filename_list = ['INTRUSION']
+patient_output_filename = patient_clean_directory + '/PATIENT_CLEANED.csv'
 
-# Using the clean_zip_files function to join the occupant and eject files for each year in CISS
-# and then union each years file into a patient dataset
-CISS_Utils.clean_zip_files(patient_raw_zipped_directory, occupant_filename, eject_filename,
-                           CISS_Constants.patient_join_columns, CISS_Constants.patient_output_columns,
-                           CISS_Constants.ciss_patient_col_specific_value_maps, output_filename)
+# Setting variables for commonly used column names, filter lists, and maps to rename columns
+intrusion_column_name = 'INTRUSION'
+intrusion_direction_column_name = 'INTDIRECT'
+lateral_and_longitudinal_intrusion_directions = ['2', '3']
+unknown_intrusion_values = ['888', '999']
+max_intrusion_by_seat_loc_column_map = {'2': 'MAXSEATLOCLONGITUDINALINTRUSION', '3': 'MAXSEATLOCLATERALINTRUSION'}
+max_intrusion_by_vehicle_column_map = {'2': 'MAXVEHICLELONGITUDINALINTRUSION', '3': 'MAXVEHICLELATERALINTRUSION'}
+
+# Using the clean_zip_files function to join the occupant, eject, gv and crash files for each year in CISS
+# and then union each years file into a base patient dataset
+ciss_patient_df = CISS_Utils.clean_zip_files(patient_raw_zipped_directory, patient_base_input_filename_list,
+                                             CISS_Constants.patient_join_columns_list,
+                                             CISS_Constants.patient_use_cols_list,
+                                             CISS_Constants.patient_output_columns)
+
+# Using the clean_zip_files function to union each years intrusion file into an intrusion dataset
+ciss_intrusion_df = CISS_Utils.clean_zip_files(patient_raw_zipped_directory, intrusion_filename_list,
+                                               [], [], CISS_Constants.intrusion_output_columns)
+
+# Filter to lateral and longitudinal intrusions that have known intrusion measurements
+ciss_intrusion_df = ciss_intrusion_df[(ciss_intrusion_df[intrusion_direction_column_name].isin(lateral_and_longitudinal_intrusion_directions)) &
+                                      ~(ciss_intrusion_df[intrusion_column_name].isin(unknown_intrusion_values))]
+
+# Convert intrusion column to int before computing the max intrusions
+ciss_intrusion_df[intrusion_column_name] = ciss_intrusion_df[intrusion_column_name].astype(int)
+
+# Using pivot_and_join_dfs function to calculate the max lateral and longitudinal intrusions by seat location and
+# join them into the patient dataframe
+ciss_patient_df = CISS_Utils.pivot_and_join_dfs(ciss_patient_df, ciss_intrusion_df, intrusion_column_name,
+                                                CISS_Constants.seat_loc_intrusion_column_list,
+                                                intrusion_direction_column_name, 'max',
+                                                max_intrusion_by_seat_loc_column_map,
+                                                CISS_Constants.seat_loc_intrusion_column_list)
+
+# Using pivot_and_join_dfs function to calculate the max lateral and longitudinal intrusions by vehicle and
+# join them into the patient dataframe
+ciss_patient_df = CISS_Utils.pivot_and_join_dfs(ciss_patient_df, ciss_intrusion_df, intrusion_column_name,
+                                                CISS_Constants.intrusion_base_column_list,
+                                                intrusion_direction_column_name, 'max',
+                                                max_intrusion_by_vehicle_column_map,
+                                                CISS_Constants.intrusion_base_column_list)
+
+ciss_patient_df = Global_Utils.clean_column_values(ciss_patient_df, CISS_Constants.ciss_patient_col_specific_value_maps, {})
+
+ciss_patient_df.to_csv(patient_output_filename, encoding='utf-8', index=False)

--- a/CISS/transforms/CISS_Patient_Value_Map.py
+++ b/CISS/transforms/CISS_Patient_Value_Map.py
@@ -111,5 +111,41 @@ ciss_patient_col_specific_value_maps = {
                         '7': 'Other type belt (specify)', '8': 'Police indicated "unknown"', '9': 'Not reported'
                         } | Global_Constants.belt_use_shared_mapping
         }
+    ],
+    'CURBWT': [
+        {
+            'ranges': Global_Constants.common_ciss_year_range,
+            'mapping': {'9999': 'Unknown'}
+        }
+    ],
+    'DVTOTAL': [
+        {
+            'ranges': Global_Constants.common_ciss_year_range,
+            'mapping': {'999': 'Unknown'}
+        }
+    ],
+    'MAXSEATLOCLONGITUDINALINTRUSION': [
+        {
+            'ranges': Global_Constants.common_ciss_year_range,
+            'mapping': Global_Constants.intrusion_shared_mapping
+        }
+    ],
+    'MAXSEATLOCLATERALINTRUSION': [
+        {
+            'ranges': Global_Constants.common_ciss_year_range,
+            'mapping': Global_Constants.intrusion_shared_mapping
+        }
+    ],
+    'MAXVEHICLELONGITUDINALINTRUSION': [
+        {
+            'ranges': Global_Constants.common_ciss_year_range,
+            'mapping': Global_Constants.intrusion_shared_mapping
+        }
+    ],
+    'MAXVEHICLELATERALINTRUSION': [
+        {
+            'ranges': Global_Constants.common_ciss_year_range,
+            'mapping': Global_Constants.intrusion_shared_mapping
+        }
     ]
 }

--- a/Global_Constants.py
+++ b/Global_Constants.py
@@ -13,3 +13,4 @@ ejection_shared_mapping = {'0': 'None', '1': 'Complete ejection', '2': 'Partial 
 treatment_shared_mapping = {'0': 'No treatment', '3': 'Hospitalization', '8': 'Treatment-other', '9': 'Unknown'}
 hospstay_shared_mapping = {'61': '61 days or more', '99': 'Unknown'}
 belt_use_shared_mapping = {'0': 'None used', '1': 'Shoulder belt', '2': 'Lap belt', '3': 'Lap and shoulder belt'}
+intrusion_shared_mapping = {'997': 'Catastrophic'}


### PR DESCRIPTION
Here is a summary of the major changes in this PR:
1. Adding in the ability for the clean_zip_files function in the CISS_Utils.py file to take in a list of files and join the files successively. With this I added in data from the GV and CRASH tables in CISS based on Dr. Hartka's request
2. Adding in a pivot_and_join_dfs function in the CISS_Utils.py file to pivot an input df and join it with another df. I am using this to calculate the max intrusion for each seat location and for each vehicle in its entirety and join it into the patient dataset.
We may need to refactor some of the logic, but I think both of these additions may be helpful for cleaning up the patient data from the other date ranges (especially the most recent NASS data)